### PR TITLE
Comparing to 48 hours instead of 48 minutes.

### DIFF
--- a/public/partials/class-blognomic-tweaks-post-classes-dynamic-tag.php
+++ b/public/partials/class-blognomic-tweaks-post-classes-dynamic-tag.php
@@ -42,7 +42,7 @@ Class BlogNomic_Post_Classes_Tag extends \Elementor\Core\DynamicTags\Tag {
     $post_freshness = 'fresh';
 
     // If post is over 48 hours old...
-    if($now - $published > (60 * 48)) {
+    if($now - $published > (60 * 60 * 48)) {
       $post_freshness = 'stale';
     }
 


### PR DESCRIPTION
Time math produces results in seconds, not minutes.