### PR TITLE
Gah, why not make it all three options?

### DIFF
--- a/public/class-blognomic-tweaks-public.php
+++ b/public/class-blognomic-tweaks-public.php
@@ -103,9 +103,11 @@ class Blognomic_Tweaks_Public {
 	public function dynamic_tags($dynamic_tags) {
 		include_once __DIR__ . '/partials/class-blognomic-tweaks-post-classes-dynamic-tag.php';
 		include_once __DIR__ . '/partials/class-blognomic-tweaks-title-with-category-dynamic-tag.php';
+		include_once __DIR__ . '/partials/class-blognomic-tweaks-title-with-category-and-tags-dynamic-tag.php';
 		include_once __DIR__ . '/partials/class-blognomic-tweaks-title-with-tags-only-dynamic-tag.php';
 		$dynamic_tags->register_tag('BlogNomic_Post_Classes_Tag');
 		$dynamic_tags->register_tag('BlogNomic_Title_With_Category_Tag');
+		$dynamic_tags->register_tag('BlogNomic_Title_With_Category_And_Tags_Tag');
 		$dynamic_tags->register_tag('BlogNomic_Title_With_Tags_Only_Tag');
 	}
 

--- a/public/partials/class-blognomic-tweaks-title-with-category-and-tags-dynamic-tag.php
+++ b/public/partials/class-blognomic-tweaks-title-with-category-and-tags-dynamic-tag.php
@@ -43,7 +43,7 @@ Class BlogNomic_Title_With_Category_And_Tags_Tag extends \Elementor\Core\Dynamic
         $tags
       );
 
-      $title_tags = ' [' . implode(', ', $tags). ']';
+      $title_tags = ' <span style="opacity:0.5">[' . implode(', ', $tags). ']</span>';
     }
 
     print $title_category . $post->post_title . $title_tags;

--- a/public/partials/class-blognomic-tweaks-title-with-category-and-tags-dynamic-tag.php
+++ b/public/partials/class-blognomic-tweaks-title-with-category-and-tags-dynamic-tag.php
@@ -1,0 +1,51 @@
+<?php
+
+Class BlogNomic_Title_With_Category_And_Tags_Tag extends \Elementor\Core\DynamicTags\Tag {
+	public function get_name() {
+    return 'blognomic-title-with-category-and-tags';
+  }
+
+	public function get_title() {
+    return __('BlogNomic title with category and tags', 'blognomic-tweaks');
+  }
+
+	public function get_group() {
+    return 'post';
+  }
+
+	public function get_categories() {
+    return [ \Elementor\Modules\DynamicTags\Module::TEXT_CATEGORY ];
+  }
+
+	public function render() {
+    $post = get_post();
+
+    $categories = get_the_terms($post, 'category');
+
+    $title_category = '';
+
+    foreach($categories as $category) {
+      if($category->slug !== 'uncategorized') {
+        $title_category = $category->name . ': ';
+        break;
+      }
+    }
+
+    $tags = get_the_terms($post, 'post_tag');
+
+    $title_tags = '';
+
+    if(!empty($tags)) {
+      $tags = array_map(
+        function($tag) {
+          return $tag->name;
+        },
+        $tags
+      );
+
+      $title_tags = ' [' . implode(', ', $tags). ']';
+    }
+
+    print $title_category . $post->post_title . $title_tags;
+  }
+}

--- a/public/partials/class-blognomic-tweaks-title-with-category-dynamic-tag.php
+++ b/public/partials/class-blognomic-tweaks-title-with-category-dynamic-tag.php
@@ -6,7 +6,7 @@ Class BlogNomic_Title_With_Category_Tag extends \Elementor\Core\DynamicTags\Tag 
   }
 
 	public function get_title() {
-    return __('BlogNomic title with category and tags', 'blognomic-tweaks');
+    return __('BlogNomic title with category', 'blognomic-tweaks');
   }
 
 	public function get_group() {
@@ -31,21 +31,6 @@ Class BlogNomic_Title_With_Category_Tag extends \Elementor\Core\DynamicTags\Tag 
       }
     }
 
-    $tags = get_the_terms($post, 'post_tag');
-
-    $title_tags = '';
-
-    if(!empty($tags)) {
-      $tags = array_map(
-        function($tag) {
-          return $tag->name;
-        },
-        $tags
-      );
-
-      $title_tags = ' [' . implode(', ', $tags). ']';
-    }
-
-    print $title_category . $post->post_title . $title_tags;
+    print $title_category . $post->post_title;
   }
 }

--- a/public/partials/class-blognomic-tweaks-title-with-tags-only-dynamic-tag.php
+++ b/public/partials/class-blognomic-tweaks-title-with-tags-only-dynamic-tag.php
@@ -32,7 +32,7 @@ Class BlogNomic_Title_With_Tags_Only_Tag extends \Elementor\Core\DynamicTags\Tag
         $tags
       );
 
-      $title_tags = ' [' . implode(', ', $tags). ']';
+      $title_tags = ' <span style="opacity:0.5">[' . implode(', ', $tags). ']</span>';
     }
 
     print $post->post_title . $title_tags;


### PR DESCRIPTION
Tags appearing in titles seems to be making people think they should continue to put tags in titles and not in the tag box. Expanding scope to the full three options, and thinking about other ways to resolve this one.